### PR TITLE
Parse found ids to integer

### DIFF
--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -83,7 +83,7 @@ module Tanker
       results = index.search(query, options)
 
       ids = unless results["results"].empty?
-        results["results"].map{|res| res["docid"].split(" ", 2)[1]}
+        results["results"].map{ |res| res["docid"].split(" ", 2)[1].to_i }
       else
         []
       end


### PR DESCRIPTION
Paco, en alguna versión reciente de Rails, el método .find() espera sólo enteros como los ids. Está raro...

En fin, la gema encuentra los ids de tanker, pero los trata de buscar como strings...

`self.find(["1", "2"])`

Esto da un error... así que tienes que pasarle forzosamente ints, `self.find([1, 2])`
