### PR TITLE
Major update to Tanker

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -52,9 +52,19 @@ in the IndexTank Dashboard
         indexes :title
         indexes :content
         indexes :tag_list #NOTICE this is an array of Tags! Awesome!
+
         # you may also dynamically retrieve field data
         indexes :author_names do |topic|
           topic.authors.map {|author| author.name }
+        end
+
+        # to pass in a list of variables with your document,
+        # supply a hash with the variable integers as keys:
+        variables do |topic|
+          {
+            0 => topic.popularity, # these will be available in your queries
+            1 => topic.id          # as doc.var[0] and doc.var[1]
+          }
         end
       end
       

--- a/README.rdoc
+++ b/README.rdoc
@@ -39,6 +39,7 @@ in the IndexTank Dashboard
     
     class Topic < ActiveRecord::Base
       acts_as_taggable
+      has_many :authors
       
       # just include the Tanker module
       include Tanker
@@ -51,6 +52,10 @@ in the IndexTank Dashboard
         indexes :title
         indexes :content
         indexes :tag_list #NOTICE this is an array of Tags! Awesome!
+        # you may also dynamically retrieve field data
+        indexes :author_names do |topic|
+          topic.authors.map {|author| author.name }
+        end
       end
       
       # define the callbacks to update or delete the index

--- a/README.rdoc
+++ b/README.rdoc
@@ -54,16 +54,16 @@ in the IndexTank Dashboard
         indexes :tag_list #NOTICE this is an array of Tags! Awesome!
 
         # you may also dynamically retrieve field data
-        indexes :author_names do |topic|
-          topic.authors.map {|author| author.name }
+        indexes :author_names do
+          authors.map {|author| author.name }
         end
 
         # to pass in a list of variables with your document,
         # supply a hash with the variable integers as keys:
-        variables do |topic|
+        variables do
           {
-            0 => topic.popularity, # these will be available in your queries
-            1 => topic.id          # as doc.var[0] and doc.var[1]
+            0 => popularity, # these will be available in your queries
+            1 => id          # as doc.var[0] and doc.var[1]
           }
         end
       end

--- a/README.rdoc
+++ b/README.rdoc
@@ -51,6 +51,7 @@ in the IndexTank Dashboard
       tankit 'my_index' do
         indexes :title
         indexes :content
+        indexes :id
         indexes :tag_list #NOTICE this is an array of Tags! Awesome!
 
         # you may also dynamically retrieve field data
@@ -62,8 +63,8 @@ in the IndexTank Dashboard
         # supply a hash with the variable integers as keys:
         variables do
           {
-            0 => popularity, # these will be available in your queries
-            1 => id          # as doc.var[0] and doc.var[1]
+            0 => authors.first.id, # these will be available in your queries
+            1 => id                # as doc.var[0] and doc.var[1]
           }
         end
       end
@@ -92,6 +93,15 @@ Search Topics
     @topics = Topic.search_tank('Topic', :page => 1, :per_page => 10) # Gets 3 results!
     @topics = Topic.search_tank('blah',  :conditions => {:tag_list => 'tag1'}) # Gets 2 results!
     @topics = Topic.search_tank('blah',  :conditions => {:title => 'Awesome', :tag_list => 'tag1'}) # Gets 1 result!
+
+Search multiple models
+
+    @results = Tanker.search([Topic, Post], 'blah') # Gets any Topic OR Post results that match!
+
+Search with negative conditions
+
+    @topics = Topic.search_tank('keyword',  :conditions => {'tag_list' => 'tag1'}) # Gets 1 result!
+    @topics = Topic.search_tank('keyword',  :conditions => {'-id' => [5,9]}) # Ignores documents with ids of '5' or '9'
 
 Paginate Results
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -119,7 +119,7 @@ Paginate Results
 
     <% will_paginate(@topics) %>
 
-== Geographic Search Example
+== Geospatial Search Example
 
 IndexTank and the Tanker gem support native geographic calculations. All you need is to define two document variables with your latitude and your longitude
  

--- a/README.rdoc
+++ b/README.rdoc
@@ -133,7 +133,11 @@ To reindex just one class rather than all the classes in your application just c
 
 And if you'd like to specify a custom number of records to PUT with each call to indextank.com you may specify it as the first argument:
 
-    Model.tanker_reindex(1000) # defaults to batch size of 200
+    Model.tanker_reindex(:batch_size => 1000) # defaults to batch size of 200
+
+Or you can restrict indexing to a subset of records. This is particularly helpful for massive datasets where only a small portion of the records is useful.
+
+    Model.tanker_reindex(:batch_size => 1000, :scope => :not_deleted) # will call Model.not_deleted.all internally
 
 
 == TODO

--- a/README.rdoc
+++ b/README.rdoc
@@ -103,6 +103,10 @@ Search with negative conditions
     @topics = Topic.search_tank('keyword',  :conditions => {'tag_list' => 'tag1'}) # Gets 1 result!
     @topics = Topic.search_tank('keyword',  :conditions => {'-id' => [5,9]}) # Ignores documents with ids of '5' or '9'
 
+Search with query variables
+
+    @topics = Topic.search_tank('keyword',  :variables => {0 => 5.6}) # Makes q[0] available server-side as 5.6
+
 Paginate Results
 
     <% will_paginate(@topics) %>
@@ -122,6 +126,15 @@ you have enough indexes in your account.
 This task re-indexes all the your models that have the Tanker module included.
 Usually you will only need a single Index Tank index but if you want to separate
 your indexes please use different index names in the tankit method call in your models
+
+To reindex just one class rather than all the classes in your application just call:
+
+    Model.tanker_reindex
+
+And if you'd like to specify a custom number of records to PUT with each call to indextank.com you may specify it as the first argument:
+
+    Model.tanker_reindex(1000) # defaults to batch size of 200
+
 
 == TODO
 * Documentation

--- a/README.rdoc
+++ b/README.rdoc
@@ -60,7 +60,7 @@ in the IndexTank Dashboard
 
         # to pass in a list of variables with your document,
         # supply a hash with the variable integers as keys:
-        index_variables do |topic|
+        variables do |topic|
           {
             0 => topic.popularity, # these will be available in your queries
             1 => topic.id          # as doc.var[0] and doc.var[1]

--- a/README.rdoc
+++ b/README.rdoc
@@ -60,7 +60,7 @@ in the IndexTank Dashboard
 
         # to pass in a list of variables with your document,
         # supply a hash with the variable integers as keys:
-        variables do |topic|
+        index_variables do |topic|
           {
             0 => topic.popularity, # these will be available in your queries
             1 => topic.id          # as doc.var[0] and doc.var[1]

--- a/README.rdoc
+++ b/README.rdoc
@@ -113,11 +113,71 @@ Search with negative conditions
 
 Search with query variables
 
-    @topics = Topic.search_tank('keyword',  :variables => {0 => 5.6}) # Makes q[0] available server-side as 5.6
+    @topics = Topic.search_tank('keyword',  :variables => {0 => 5.6}) # Makes 5.6 available server-side as q[0]
 
 Paginate Results
 
     <% will_paginate(@topics) %>
+
+== Geographic Search Example
+
+IndexTank and the Tanker gem support native geographic calculations. All you need is to define two document variables with your latitude and your longitude
+ 
+    class Restaurant < ActiveRecord::Base
+      include Tanker
+
+      tankit 'my_index' do
+        indexes :name
+
+        # You may define lat/lng at any variable number you like, as long
+        # as you refer to them consistently with the same integers
+        variables do
+          {
+            0 => lat
+            1 => lng
+          }
+        end
+
+        functions do
+          {
+            # This function is good for sorting your results. It will
+            # rank relevant, close results higher and irrelevant, distant results lower
+            1 => "relevance / miles(d[0], d[1], q[0], q[1])",
+
+            # This function is useful for limiting the results that your query returns.
+            # It just calculates the distance of each document in miles, which you can use
+            # in your query. Notice that we're using 0 and 1 consistently as 'lat' and 'lng'
+            2 => "miles(d[0], d[1], q[0], q[1])"
+          }
+        end
+      end
+    end
+    
+    # When searching, you need to provide a latitude and longitude in the query so that
+    # these variables are accessible on the server.
+    Restaurant.search("tasty",
+                      :var0 => 47.689948,
+                      :var1 => -122.363684,
+                      # And we'll return all results sorted by distance
+                      :function => 1)
+
+    # Or we can use just function 2 to return results in the default order, while
+    # limiting the total results to just those within 50 miles from our lat/lng:
+    Restaurant.search("tasty",
+                      :var0 => 47.689948,
+                      :var1 => -122.363684,
+                      # the following is a fancy way of saying "return all results where
+                      the result of function 2 is at least anything and less than 50"
+                      :filter_functions => {2 => [['*', 50]]})
+    # And we can combine these two function calls to return only results within 50 miles
+    # and sort them by relevance / distance:
+    Restaurant.search("tasty",
+                      :var0 => 47.689948,
+                      :var1 => -122.363684,
+                      :function => 1,
+                      :filter_functions => {2 => [['*', 50]]})
+
+
 
 == Reindex your data
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,7 +1,5 @@
 = Tanker - IndexTank integration to your favorite orm
 
-*Note:* This gem is still quite alpha but please feel free to send comments
-
 IndexTank is a great search indexing service, this gem tries to make 
 any orm keep in sync with indextank with ease. This gem has a simple 
 but powerful approach to integrating IndexTank to any orm. The gem 

--- a/README.rdoc
+++ b/README.rdoc
@@ -190,6 +190,10 @@ the indexes in the Index Tank interface this task creates them for you provided
 you have enough indexes in your account.
 
     rake tanker:reindex
+
+This task pushes any functions you've defined in your tankit() blocks to indextank.com
+
+    rake tanker:functions
     
 This task re-indexes all the your models that have the Tanker module included.
 Usually you will only need a single Index Tank index but if you want to separate

--- a/README.rdoc
+++ b/README.rdoc
@@ -67,6 +67,16 @@ in the IndexTank Dashboard
             1 => id                # as doc.var[0] and doc.var[1]
           }
         end
+
+        # You may defined some server-side functions that can be
+        # referenced in your queries. They're always referenced by
+        # their integer key:
+        functions do
+          {
+            1 => '-age',
+            2 => 'doc.var[0] - doc.var[1]'
+          }
+        end
       end
       
       # define the callbacks to update or delete the index

--- a/Rakefile
+++ b/Rakefile
@@ -21,10 +21,11 @@ end
 
 require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|
-  test.libs << 'lib' << 'test'
-  test.pattern = 'test/**/test_*.rb'
+  test.libs << 'lib' << 'spec'
+  test.pattern = 'spec/*_spec.rb'
   test.verbose = true
 end
+task :spec => :test
 
 begin
   require 'rcov/rcovtask'

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ begin
     gem.description = %Q{IndexTank is a great search indexing service, this gem tries to make any orm keep in sync with indextank with ease}
     gem.email = "kidpollo@gmail.com"
     gem.homepage = "http://github.com/kidpollo/tanker"
-    gem.authors = ["@kidpollo"]
+    gem.authors = ["@kidpollo", "Jack Danger Canty"]
     gem.add_development_dependency "rspec", ">= 2.0.0.beta.22"
     gem.add_dependency 'will_paginate', '>= 2.3.15'
     # gem is a Gem::Specification... see http://www.rubygems.org/read/chapter/20 for additional settings

--- a/lib/indextank_client.rb
+++ b/lib/indextank_client.rb
@@ -139,6 +139,11 @@ module IndexTank
             return r
         end
 
+        def add_documents(data_array)
+            code, r = PUT "/docs", data_array
+            return r
+        end
+
         def update_variables(docid, variables, options={})
             options.merge!( :docid => docid, :variables => variables )
             code, r = PUT "/docs/variables", options

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -222,7 +222,7 @@ module Tanker
         data[field.to_sym] = val.to_s unless val.nil?
       end
 
-      data[:__any] = data.values.join " . "
+      data[:__any] = data.values.sort_by{|v| v.to_s}.join " . "
       data[:__type] = self.class.name
 
       data

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -165,10 +165,6 @@ module Tanker
         data[field.to_s] = val.to_s unless val.nil?
       end
 
-      if tanker_variables
-        options[:variables] = tanker_variables.call(self)
-      end
-
       data[:__any] = data.values.join " . "
       data[:__type] = self.class.name
 

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -154,6 +154,25 @@ module Tanker
     def tanker_index
       tanker_config.index
     end
+
+    def tanker_reindex(batch_size = 200)
+      puts "Indexing #{self} model"
+
+      batches = []
+      total_records = all.size
+
+      all.each_with_index do |model_instance, idx|
+        batch_num = idx / batch_size
+        (batches[batch_num] ||= []) << model_instance
+      end
+
+      timer = Time.now
+      batches.each_with_index do |batch, idx|
+        Tanker.batch_update(batch)
+        puts "Indexed #{batch.size} records   #{(idx * batch_size) + batch.size}/#{total_records}"
+      end
+      puts "Indexed #{total_records} #{self} records in #{Time.now - timer} seconds"
+    end
   end
 
   class ModelConfig

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -89,8 +89,8 @@ module Tanker
 
     def search_tank(query, options = {})
       ids      = []
-      page     = options.delete(:page).to_i || 1
-      per_page = options.delete(:per_page).to_i || self.per_page
+      page     = (options.delete(:page) || 1).to_i
+      per_page = (options.delete(:per_page) || self.per_page).to_i
 
       # transform fields in query
       if conditions = options.delete(:conditions)

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -58,8 +58,8 @@ module Tanker
       end
     end
 
-    def indexes(field)
-      @tanker_indexes << field
+    def indexes(field, &block)
+      @tanker_indexes << [field, block].flatten
     end
 
     def index
@@ -113,8 +113,8 @@ module Tanker
     def update_tank_indexes
       data = {}
 
-      tanker_indexes.each do |field|
-        val = self.instance_eval(field.to_s)
+      tanker_indexes.each do |field, block|
+        val = block ? block.call(self) : self.instance_eval(field.to_s)
         data[field.to_s] = val.to_s unless val.nil?
       end
 

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -155,23 +155,25 @@ module Tanker
       tanker_config.index
     end
 
-    def tanker_reindex(batch_size = 200)
+    def tanker_reindex(options = {})
       puts "Indexing #{self} model"
 
       batches = []
-      total_records = all.size
+      options[:batch_size] ||= 200
+      records = options[:scope] ? send(options[:scope]).all : all
+      record_size = records.size
 
-      all.each_with_index do |model_instance, idx|
-        batch_num = idx / batch_size
+      records.each_with_index do |model_instance, idx|
+        batch_num = idx / options[:batch_size]
         (batches[batch_num] ||= []) << model_instance
       end
 
       timer = Time.now
       batches.each_with_index do |batch, idx|
         Tanker.batch_update(batch)
-        puts "Indexed #{batch.size} records   #{(idx * batch_size) + batch.size}/#{total_records}"
+        puts "Indexed #{batch.size} records   #{(idx * options[:batch_size]) + batch.size}/#{record_size}"
       end
-      puts "Indexed #{total_records} #{self} records in #{Time.now - timer} seconds"
+      puts "Indexed #{record_size} #{self} records in #{Time.now - timer} seconds"
     end
   end
 

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -179,11 +179,12 @@ module Tanker
   end
 
   class ModelConfig
-    attr_reader :indexes, :variables, :index_name
+    attr_reader :index_name
 
     def initialize(index_name, block)
       @index_name = index_name
-      @indexes = []
+      @indexes    = []
+      @functions  = {}
       instance_exec &block
     end
 
@@ -195,6 +196,11 @@ module Tanker
     def variables(&block)
       @variables = block if block
       @variables
+    end
+
+    def functions(&block)
+      @functions = block.call if block
+      @functions
     end
 
     def index

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -74,13 +74,10 @@ module Tanker
 
       # transform fields in query
       if conditions = options.delete(:conditions)
-        conditions.each do |field,value|
-          if value.is_a?(Array)
-            value.each do |item|
-              query += " #{field}:(#{item})"
-            end
-          else
-            query += " #{field}:(#{value})"
+        conditions.each do |field, value|
+          value = [value].flatten
+          value.each do |item|
+            query += " #{field}:(#{item})"
           end
         end
       end

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -155,6 +155,7 @@ module Tanker
 
       tanker_indexes.each do |field, block|
         val = block ? block.call(self) : self.instance_eval(field.to_s)
+        val = val.join(' ') if Array === val
         data[field.to_s] = val.to_s unless val.nil?
       end
 

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -72,13 +72,22 @@ module Tanker
       end
 
 
-      # transform fields in query
+      # move conditions into the query body
       if conditions = options.delete(:conditions)
         conditions.each do |field, value|
           value = [value].flatten.compact
           value.each do |item|
             query += " #{field}:(#{item})"
           end
+        end
+      end
+
+      # rephrase filter_functions
+      if filter_functions = options.delete(:filter_functions)
+        filter_functions.each do |function_number, ranges|
+          options[:"filter_function#{function_number}"] = ranges.map do |range|
+            range.join(':')
+          end.join(',')
         end
       end
 

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -93,8 +93,8 @@ module Tanker
       per_page = options.delete(:per_page) || self.per_page
 
       # transform fields in query
-      if options.has_key? :conditions
-        options[:conditions].each do |field,value|
+      if conditions = options.delete(:conditions)
+        conditions.each do |field,value|
           query += " #{field}:(#{value})"
         end
       end

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -83,7 +83,7 @@ module Tanker
       results = index.search(query, options)
 
       ids = unless results["results"].empty?
-        results["results"].map{|res| res["docid"].split(" ", 2)[1]}
+        results["results"].map{ |res| res["docid"].split(" ", 2)[1].to_i }
       else
         []
       end

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -85,9 +85,14 @@ module Tanker
       # rephrase filter_functions
       if filter_functions = options.delete(:filter_functions)
         filter_functions.each do |function_number, ranges|
-          options[:"filter_function#{function_number}"] = ranges.map do |range|
-            range.join(':')
-          end.join(',')
+          options[:"filter_function#{function_number}"] = ranges.map{|r|r.join(':')}.join(',')
+        end
+      end
+
+      # rephrase filter_docvars
+      if filter_docvars = options.delete(:filter_docvars)
+        filter_docvars.each do |var_number, ranges|
+          options[:"filter_docvar#{var_number}"] = ranges.map{|r|r.join(':')}.join(',')
         end
       end
 

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -65,6 +65,7 @@ module Tanker
       page     = (options.delete(:page) || 1).to_i
       per_page = (options.delete(:per_page) || models.first.per_page).to_i
       index    = models.first.tanker_index
+      query    = query.join(' ') if Array === query
 
       if (index_names = models.map(&:tanker_config).map(&:index_name).uniq).size > 1
         raise "You can't search across multiple indexes in one call (#{index_names.inspect})"
@@ -74,7 +75,7 @@ module Tanker
       # transform fields in query
       if conditions = options.delete(:conditions)
         conditions.each do |field, value|
-          value = [value].flatten
+          value = [value].flatten.compact
           value.each do |item|
             query += " #{field}:(#{item})"
           end

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -128,6 +128,11 @@ module Tanker
     def update_tank_indexes
       data, options = {}, {}
 
+      # attempt to autodetect timestamp
+      if respond_to?(:created_at)
+        data[:timestamp] = created_at.to_i
+      end
+
       tanker_indexes.each do |field, block|
         val = block ? block.call(self) : self.instance_eval(field.to_s)
         data[field.to_s] = val.to_s unless val.nil?

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -89,8 +89,8 @@ module Tanker
 
     def search_tank(query, options = {})
       ids      = []
-      page     = options.delete(:page) || 1
-      per_page = options.delete(:per_page) || self.per_page
+      page     = options.delete(:page).to_i || 1
+      per_page = options.delete(:per_page).to_i || self.per_page
 
       # transform fields in query
       if conditions = options.delete(:conditions)

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -79,7 +79,7 @@ module Tanker
       @tanker_indexes << [field, block].flatten
     end
 
-    def variables(&block)
+    def index_variables(&block)
       @tanker_variables = block
     end
 

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -162,7 +162,7 @@ module Tanker
       tanker_indexes.each do |field, block|
         val = block ? block.call(self) : self.instance_eval(field.to_s)
         val = val.join(' ') if Array === val
-        data[field.to_s] = val.to_s unless val.nil?
+        data[field.to_sym] = val.to_s unless val.nil?
       end
 
       data[:__any] = data.values.join " . "

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -162,7 +162,6 @@ module Tanker
     def initialize(index_name, block)
       @index_name = index_name
       @indexes = []
-      @variables = []
       instance_exec &block
     end
 
@@ -186,7 +185,7 @@ module Tanker
   module InstanceMethods
 
     def tanker_config
-      self.class.tanker_config
+      self.class.tanker_config || raise(NotConfigured, "Please configure Tanker for #{self.class.inspect} with the 'tankit' block")
     end
 
     def tanker_indexes

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -95,7 +95,13 @@ module Tanker
       # transform fields in query
       if conditions = options.delete(:conditions)
         conditions.each do |field,value|
-          query += " #{field}:(#{value})"
+          if value.is_a?(Array)
+            value.each do |item|
+              query += " #{field}:(#{item})"
+            end
+          else
+            query += " #{field}:(#{value})"
+          end
         end
       end
 

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -1,8 +1,12 @@
-require "rubygems"
-require "bundler"
 
-Bundler.setup :default
+begin
+  require "rubygems"
+  require "bundler"
 
+  Bundler.setup :default
+rescue => e
+  puts "Tanker: #{e.message}"
+end
 require 'indextank_client'
 require 'tanker/configuration'
 require 'tanker/utilities'
@@ -10,7 +14,10 @@ require 'will_paginate/collection'
 
 
 if defined? Rails
-  require 'tanker/railtie'
+  begin
+    require 'tanker/railtie'
+  rescue LoadError
+  end
 end
 
 module Tanker

--- a/lib/tanker/tasks/tanker.rake
+++ b/lib/tanker/tasks/tanker.rake
@@ -7,6 +7,41 @@ namespace :tanker do
     Tanker::Utilities.reindex_all_models
   end
   
+  desc "Update IndexTank functions"
+  task :functions => :environment do
+    puts "reindexing all IndexTank functions"
+    load_models
+    indexes = {}
+    Tanker::Utilities.get_model_classes.each do |model|
+      model.tanker_config.functions.each do |idx, definition|
+        indexes[model.tanker_config.index_name] ||= {}
+        indexes[model.tanker_config.index_name][idx] = definition
+      end
+    end
+    if indexes.blank?
+      puts <<-HELP
+No IndexTank functions defined.
+Define your server-side functions inside your model's tankit block like so:
+  tankit 'myindex' do
+    functions do
+      {
+        1 => "-age",
+        2 => "relevance / miles(d[0], d[1], q[0], q[1])"
+      }
+    end
+  end
+HELP
+    else
+      indexes.each do |index_name, functions|
+        index = Tanker.api.get_index(index_name)
+        functions.each do |idx, definition|
+          index.add_function(idx, definition)
+          puts "Index #{index_name.inspect} function: #{idx} => #{definition.inspect}"
+        end
+      end
+    end
+  end
+  
   desc "Clear all Index Tank indexes"
   task :clear_indexes => :environment do
     puts "clearing all indexes"

--- a/lib/tanker/tasks/tanker.rake
+++ b/lib/tanker/tasks/tanker.rake
@@ -2,7 +2,7 @@ namespace :tanker do
  
   desc "Reindex all models"
   task :reindex => :environment do
-    puts "reinexing all models"
+    puts "reindexing all models"
     load_models
     Tanker::Utilities.reindex_all_models
   end

--- a/lib/tanker/utilities.rb
+++ b/lib/tanker/utilities.rb
@@ -6,7 +6,7 @@ module Tanker
       end
 
       def get_available_indexes
-        get_model_classes.map{|model| model.index_name}.uniq.compact
+        get_model_classes.map{|model| model.tanker_config.index_name}.uniq.compact
       end
 
       def clear_all_indexes

--- a/lib/tanker/utilities.rb
+++ b/lib/tanker/utilities.rb
@@ -47,7 +47,7 @@ module Tanker
           timer = Time.now
           batches.each_with_index do |batch, idx|
             Tanker.batch_update(batch)
-            puts "Indexed #{batch.size} records   #{(idx+1) * batch_size}/#{total_records}"
+            puts "Indexed #{batch.size} records   #{(idx * batch_size) + batch.size}/#{total_records}"
           end
           puts "Indexed #{total_records} #{klass} records in #{Time.now - timer} seconds"
         end

--- a/lib/tanker/utilities.rb
+++ b/lib/tanker/utilities.rb
@@ -33,8 +33,18 @@ module Tanker
       def reindex_all_models
         get_model_classes.each do |klass|
           puts "Indexing #{klass.to_s} model"
-          klass.all.each do |model_instance|
-            model_instance.update_tank_indexes
+          batches = []
+          all = klass.all
+          total_records = all.size
+          # group into batches of 50
+          batch_size = 50
+          all.each_with_index do |model_instance, idx|
+            batch_num = idx / batch_size
+            (batches[batch_num] ||= []) << model_instance
+          end
+          batches.each_with_index do |batch, idx|
+            Tanker.batch_update(batch)
+            puts "Indexed #{batch.size} records   #{(idx+1) * batch_size}/#{total_records}"
           end
         end
       end

--- a/lib/tanker/utilities.rb
+++ b/lib/tanker/utilities.rb
@@ -32,24 +32,7 @@ module Tanker
 
       def reindex_all_models
         get_model_classes.each do |klass|
-          puts "Indexing #{klass} model"
-
-          batches = []
-          all = klass.all
-          total_records = all.size
-          batch_size = 200
-
-          all.each_with_index do |model_instance, idx|
-            batch_num = idx / batch_size
-            (batches[batch_num] ||= []) << model_instance
-          end
-
-          timer = Time.now
-          batches.each_with_index do |batch, idx|
-            Tanker.batch_update(batch)
-            puts "Indexed #{batch.size} records   #{(idx * batch_size) + batch.size}/#{total_records}"
-          end
-          puts "Indexed #{total_records} #{klass} records in #{Time.now - timer} seconds"
+          klass.tanker_reindex
         end
       end
     end

--- a/lib/tanker/utilities.rb
+++ b/lib/tanker/utilities.rb
@@ -32,7 +32,7 @@ module Tanker
 
       def reindex_all_models
         get_model_classes.each do |klass|
-          puts "Indexing #{klass.to_s} model"
+          puts "Indexing #{klass} model"
           batches = []
           all = klass.all
           total_records = all.size
@@ -42,10 +42,12 @@ module Tanker
             batch_num = idx / batch_size
             (batches[batch_num] ||= []) << model_instance
           end
+          timer = Time.now
           batches.each_with_index do |batch, idx|
             Tanker.batch_update(batch)
             puts "Indexed #{batch.size} records   #{(idx+1) * batch_size}/#{total_records}"
           end
+          puts "Indexed #{total_records} #{klass} records in #{Time.now - timer} seconds"
         end
       end
     end

--- a/lib/tanker/utilities.rb
+++ b/lib/tanker/utilities.rb
@@ -33,15 +33,17 @@ module Tanker
       def reindex_all_models
         get_model_classes.each do |klass|
           puts "Indexing #{klass} model"
+
           batches = []
           all = klass.all
           total_records = all.size
-          # group into batches of 50
-          batch_size = 50
+          batch_size = 200
+
           all.each_with_index do |model_instance, idx|
             batch_num = idx / batch_size
             (batches[batch_num] ||= []) << model_instance
           end
+
           timer = Time.now
           batches.each_with_index do |batch, idx|
             Tanker.batch_update(batch)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,7 +33,7 @@ class Person
   tankit 'people' do
     indexes :name
     indexes :last_name
-    index_variables do
+    variables do
       {0 => 1.0,
        1 => 20.0,
        2 => 300.0}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,15 @@ end
 $frozen_moment = Time.now
 
 class Person
+
+  attr_accessor :name, :last_name
+
+  def initialize(attrs = {})
+    attrs.each {|k,v| self.send "#{k}=", v }
+    self.name ||= 'paco'
+    self.last_name ||= 'viramontes'
+  end
+
   include Tanker
 
   tankit 'people' do
@@ -37,14 +46,6 @@ class Person
 
   def id
     1
-  end
-
-  def name
-    'paco'
-  end
-
-  def last_name
-    'viramontes'
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,11 @@ class Person
 end
 
 class Dog
+  attr_accessor :name, :id
+  def initialize(attrs = {})
+    attrs.each {|k,v| self.send "#{k}=", v }
+  end
+
   include Tanker
 
   tankit 'animals' do
@@ -59,6 +64,11 @@ class Dog
 end
 
 class Cat
+  attr_accessor :name, :id
+  def initialize(attrs = {})
+    attrs.each {|k,v| self.send "#{k}=", v }
+  end
+
   include Tanker
 
   tankit 'animals' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,11 @@ class Person
   tankit 'people' do
     indexes :name
     indexes :last_name
+    variables do
+      {0 => 1.0,
+       1 => 20.0,
+       2 => 300.0}
+    end
   end
 
   def id

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ class Person
   tankit 'people' do
     indexes :name
     indexes :last_name
-    variables do
+    index_variables do
       {0 => 1.0,
        1 => 20.0,
        2 => 300.0}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,8 @@ class Dummy
 
 end
 
+$frozen_moment = Time.now
+
 class Person
   include Tanker
 
@@ -27,6 +29,10 @@ class Person
        1 => 20.0,
        2 => 300.0}
     end
+  end
+
+  def created_at
+    $frozen_moment
   end
 
   def id

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require File.expand_path(File.join(File.dirname(__FILE__), 'spec_helper'))
 
 describe Tanker do
 

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -83,9 +83,15 @@ describe Tanker do
     end
 
     it 'should be able to update the index' do
-      person = Person.new
+      person = Person.new(:name => 'Name', :last_name => 'Last Name')
 
-      Person.index.should_receive(:add_document)
+      Person.index.should_receive(:add_document).with(
+        Person.new.it_doc_id,
+        {:__any     => 'Name . Last Name',
+         :__type    => 'Person',
+         :name      => 'Name',
+         :last_name => 'Last Name'}
+      )
 
       person.update_tank_indexes
     end

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -91,6 +91,21 @@ describe Tanker do
       collection = Person.search_tank('hey!', :conditions => {:location_id => [1,2]})
     end
 
+    it 'should be able to use filter_functions' do
+      Person.tanker_index.should_receive(:search).with(
+        "__any:(hey!) __type:(Person)",
+        { :start => 0,
+          :len => 10,
+          :filter_function2 => "0:10,20:40"
+        }
+      ).and_return({'results' => [], 'matches' => 0})
+
+      collection = Person.search_tank('hey!',
+                                      :filter_functions => {
+                                        2 => [[0,10], [20,40]]
+                                      })
+    end
+
     it 'should be able to perform a seach query over several models' do
       index = Tanker.api.get_index('animals')
       Dog.should_receive(:tanker_index).and_return(index)

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -130,7 +130,7 @@ describe Tanker do
       Person.tanker_index.should_receive(:add_document).with(
         Person.new.it_doc_id,
         {
-          :__any     => "Last Name . #{$frozen_moment.to_i} . Name",
+          :__any     => "#{$frozen_moment.to_i} . Last Name . Name",
           :__type    => 'Person',
           :name      => 'Name',
           :last_name => 'Last Name',
@@ -155,7 +155,7 @@ describe Tanker do
         [ {
             :docid => Person.new.it_doc_id,
             :fields => {
-              :__any     => "Last Name . #{$frozen_moment.to_i} . Name",
+              :__any     => "#{$frozen_moment.to_i} . Last Name . Name",
               :__type    => 'Person',
               :name      => 'Name',
               :last_name => 'Last Name',

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -105,6 +105,20 @@ describe Tanker do
                                         2 => [[0,10], [20,40]]
                                       })
     end
+    it 'should be able to use filter_docvars' do
+      Person.tanker_index.should_receive(:search).with(
+        "__any:(hey!) __type:(Person)",
+        { :start => 0,
+          :len => 10,
+          :filter_docvar3 => "*:7,80:100"
+        }
+      ).and_return({'results' => [], 'matches' => 0})
+
+      collection = Person.search_tank('hey!',
+                                      :filter_docvars => {
+                                        3 => [['*',7], [80,100]]
+                                      })
+    end
 
     it 'should be able to perform a seach query over several models' do
       index = Tanker.api.get_index('animals')

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -33,20 +33,20 @@ describe Tanker do
     end
 
     dummy_instance = Dummy.new
-    dummy_instance.tanker_indexes.any? {|field, block| field == :field }.should == true
+    dummy_instance.tanker_config.indexes.any? {|field, block| field == :field }.should == true
   end
 
   it 'should allow blocks for indexable field data' do
     Tanker.configuration = {:url => 'http://api.indextank.com'}
     Dummy.send(:include, Tanker)
     Dummy.send(:tankit, 'dummy index') do
-      indexes :class_name do |dummy|
+      indexes :class_name do
         dummy.class.name
       end
     end
 
     dummy_instance = Dummy.new
-    dummy_instance.tanker_indexes.any? {|field, block| field == :class_name }.should == true
+    dummy_instance.tanker_config.indexes.any? {|field, block| field == :class_name }.should == true
   end
 
   describe 'tanker instance' do
@@ -55,11 +55,11 @@ describe Tanker do
     end
 
     it 'should create a connexion to index tank' do
-      Person.index.class.should == IndexTank::IndexClient
+      Person.tanker_index.class.should == IndexTank::IndexClient
     end
 
     it 'should be able to perform a seach query directly on the model' do
-      Person.index.should_receive(:search).and_return(
+      Person.tanker_index.should_receive(:search).and_return(
         {
           "matches" => 1,
           "results" => [{
@@ -83,7 +83,7 @@ describe Tanker do
     end
 
     it 'should be able to use multi-value query phrases' do
-      Person.index.should_receive(:search).with(
+      Person.tanker_index.should_receive(:search).with(
         "__any:(hey! location_id:(1) location_id:(2)) __type:(Person)",
         {:start => 0, :len => 10}
       ).and_return({'results' => [], 'matches' => 0})
@@ -93,7 +93,7 @@ describe Tanker do
 
     it 'should be able to perform a seach query over several models' do
       index = Tanker.api.get_index('animals')
-      Dog.should_receive(:index).and_return(index)
+      Dog.should_receive(:tanker_index).and_return(index)
       index.should_receive(:search).and_return(
         {
           "matches" => 2,
@@ -127,7 +127,7 @@ describe Tanker do
     it 'should be able to update the index' do
       person = Person.new(:name => 'Name', :last_name => 'Last Name')
 
-      Person.index.should_receive(:add_document).with(
+      Person.tanker_index.should_receive(:add_document).with(
         Person.new.it_doc_id,
         {
           :__any     => "Last Name . #{$frozen_moment.to_i} . Name",
@@ -151,7 +151,7 @@ describe Tanker do
     it 'should be able to batch update the index' do
       person = Person.new(:name => 'Name', :last_name => 'Last Name')
 
-      Person.index.should_receive(:add_documents).with(
+      Person.tanker_index.should_receive(:add_documents).with(
         [ {
             :docid => Person.new.it_doc_id,
             :fields => {
@@ -175,7 +175,7 @@ describe Tanker do
     it 'should be able to delete the document from the index' do
       person = Person.new
 
-      Person.index.should_receive(:delete_document)
+      Person.tanker_index.should_receive(:delete_document)
 
       person.delete_tank_indexes
     end

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -91,7 +91,8 @@ describe Tanker do
           :__any     => 'Name . Last Name',
           :__type    => 'Person',
           :name      => 'Name',
-          :last_name => 'Last Name'
+          :last_name => 'Last Name',
+          :timestamp => $frozen_moment.to_i
         },
         {
           :variables => [1.0, 20.0, 300.0]

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -82,6 +82,15 @@ describe Tanker do
       collection.current_page.should == 1
     end
 
+    it 'should be able to use multi-value query phrases' do
+      Person.index.should_receive(:search).with(
+        "__any:(hey! location_id:(1) location_id:(2)) __type:(Person)",
+        {:start => 0, :len => 10}
+      ).and_return({'results' => [], 'matches' => 0})
+
+      collection = Person.search_tank('hey!', :conditions => {:location_id => [1,2]})
+    end
+
     it 'should be able to perform a seach query over several models' do
       index = Tanker.api.get_index('animals')
       Dog.should_receive(:index).and_return(index)

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -88,14 +88,18 @@ describe Tanker do
       Person.index.should_receive(:add_document).with(
         Person.new.it_doc_id,
         {
-          :__any     => 'Name . Last Name',
+          :__any     => "Last Name . #{$frozen_moment.to_i} . Name",
           :__type    => 'Person',
           :name      => 'Name',
           :last_name => 'Last Name',
           :timestamp => $frozen_moment.to_i
         },
         {
-          :variables => [1.0, 20.0, 300.0]
+          :variables => {
+            0 => 1.0,
+            1 => 20.0,
+            2 => 300.0
+          }
         }
       )
 
@@ -106,21 +110,24 @@ describe Tanker do
       person = Person.new(:name => 'Name', :last_name => 'Last Name')
 
       Person.index.should_receive(:add_documents).with(
-        [ Person.new.it_doc_id,
-          {
-            :__any     => 'Name . Last Name',
-            :__type    => 'Person',
-            :name      => 'Name',
-            :last_name => 'Last Name',
-            :timestamp => $frozen_moment.to_i
-          },
-          {
-            :variables => [1.0, 20.0, 300.0]
-          }
-        ]
+        [ {
+            :docid => Person.new.it_doc_id,
+            :fields => {
+              :__any     => "Last Name . #{$frozen_moment.to_i} . Name",
+              :__type    => 'Person',
+              :name      => 'Name',
+              :last_name => 'Last Name',
+              :timestamp => $frozen_moment.to_i
+            },
+            :variables => {
+              0 => 1.0,
+              1 => 20.0,
+              2 => 300.0
+            }
+        } ]
       )
 
-      Tanker.batch_update[person]
+      Tanker.batch_update([person])
     end
 
     it 'should be able to delete de document from the index' do

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -87,10 +87,15 @@ describe Tanker do
 
       Person.index.should_receive(:add_document).with(
         Person.new.it_doc_id,
-        {:__any     => 'Name . Last Name',
-         :__type    => 'Person',
-         :name      => 'Name',
-         :last_name => 'Last Name'}
+        {
+          :__any     => 'Name . Last Name',
+          :__type    => 'Person',
+          :name      => 'Name',
+          :last_name => 'Last Name'
+        },
+        {
+          :variables => [1.0, 20.0, 300.0]
+        }
       )
 
       person.update_tank_indexes

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -163,7 +163,7 @@ describe Tanker do
       Tanker.batch_update([person])
     end
 
-    it 'should be able to delete de document from the index' do
+    it 'should be able to delete the document from the index' do
       person = Person.new
 
       Person.index.should_receive(:delete_document)

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -33,7 +33,7 @@ describe Tanker do
     end
 
     dummy_instance = Dummy.new
-    dummy_instance.tanker_indexes.include?(:field).should == true
+    dummy_instance.tanker_indexes.any? {|field, block| field == :field }.should == true
   end
 
   it 'should allow blocks for indexable field data' do
@@ -46,7 +46,7 @@ describe Tanker do
     end
 
     dummy_instance = Dummy.new
-    dummy_instance.tanker_indexes.include?(:class_name).should == true
+    dummy_instance.tanker_indexes.any? {|field, block| field == :class_name }.should == true
   end
 
   describe 'tanker instance' do

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -36,6 +36,19 @@ describe Tanker do
     dummy_instance.tanker_indexes.include?(:field).should == true
   end
 
+  it 'should allow blocks for indexable field data' do
+    Tanker.configuration = {:url => 'http://api.indextank.com'}
+    Dummy.send(:include, Tanker)
+    Dummy.send(:tankit, 'dummy index') do
+      indexes :class_name do |dummy|
+        dummy.class.name
+      end
+    end
+
+    dummy_instance = Dummy.new
+    dummy_instance.tanker_indexes.include?(:class_name).should == true
+  end
+
   describe 'tanker instance' do
     it 'should create an api instance' do
       Tanker.api.class.should == IndexTank::ApiClient

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -41,7 +41,7 @@ describe Tanker do
     Dummy.send(:include, Tanker)
     Dummy.send(:tankit, 'dummy index') do
       indexes :class_name do
-        dummy.class.name
+        self.class.name
       end
     end
 

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -102,6 +102,27 @@ describe Tanker do
       person.update_tank_indexes
     end
 
+    it 'should be able to batch update the index' do
+      person = Person.new(:name => 'Name', :last_name => 'Last Name')
+
+      Person.index.should_receive(:add_documents).with(
+        [ Person.new.it_doc_id,
+          {
+            :__any     => 'Name . Last Name',
+            :__type    => 'Person',
+            :name      => 'Name',
+            :last_name => 'Last Name',
+            :timestamp => $frozen_moment.to_i
+          },
+          {
+            :variables => [1.0, 20.0, 300.0]
+          }
+        ]
+      )
+
+      Tanker.batch_update[person]
+    end
+
     it 'should be able to delete de document from the index' do
       person = Person.new
 

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require File.expand_path(File.join(File.dirname(__FILE__), 'spec_helper'))
 
 class Dummy
   include Tanker


### PR DESCRIPTION
Ahoy Kidpollo!

Thanks for the fantastic work with Tanker! I really love it, it saved me weeks of work.

I've been using Sunspot and Solr for a year and I just switched to IndexTank. I tried ThinkingTank but it was nowhere near production-ready. Instead I forked Tanker and started adding all the functionality I've grown accustomed to from other search ORM extensions.

What I've added to Tanker:

block-style field definitions:

```
tankit 'index' do
  indexes :author_names do
    authors.map(&:name)
  end
end
```

document variable definitions

```
tankit 'index' do
  variables do
    {0 => id,
     1 => lat,
     2 => lng}
  end
end
```

Multi-class searching:

```
Tanker.search([Topic,User,Post], 'keyword') # returns mixed results of different types
```

Single-class reindexing:

```
Topic.tanker_reindex
```

Oh, and batch indexing. When you run 'rake tanker:reindex' it'll now default to indexing and PUTting 200 records at a time. WAY, WAY, faster than doing it one at a time. I'm indexing 800 records in about 15 seconds.

Automatic timestamping: if the object responds to 'created_at' then that'll be set as the document's creation time in the index.

I also cleaned up the 'tankit' configuration call so it doesn't pollute class-level and object-level methods. I put it into a ModelConfig class so users don't have their Topic.index, Topic.indexes, etc. methods overwritten.

I've added specs for everything and did my best to preserve all of your original organization. I didn't mess with anything that I didn't have to. I've also updated the README.

Care to push a new gem version? :)
