### PR TITLE
Id field

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "http://rubygems.org"
 
 gem 'jeweler'
+gem 'json', '>= 1.5.1'
 gem 'will_paginate', '>= 2.3.15'
 
 group :test do

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -273,6 +273,7 @@ module Tanker
 
       data[:__any] = data.values.sort_by{|v| v.to_s}.join " . "
       data[:__type] = self.class.name
+      data[:__id] = self.id
 
       data
     end

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -119,7 +119,8 @@ module Tanker
         return [] if results.empty?
 
         id_map = results.inject({}) do |acc, result|
-          model, id = result["__type"], result["__id"]
+          model = result["__type"]
+          id = constantize(model).tanker_parse_doc_id(result)
           acc[model] ||= []
           acc[model] << id.to_i
           acc
@@ -136,7 +137,8 @@ module Tanker
           end
           # return them in order
           results.map do |result|
-            model, id = result["__type"], result["__id"]
+            model = result["__type"]
+            id = constantize(model).tanker_parse_doc_id(result)
             id_map[model].detect {|record| id.to_i == record.id }
           end
         end
@@ -190,6 +192,10 @@ module Tanker
         puts "Indexed #{batch.size} records   #{(idx * options[:batch_size]) + batch.size}/#{record_size}"
       end
       puts "Indexed #{record_size} #{self} records in #{Time.now - timer} seconds"
+    end
+
+    def tanker_parse_doc_id(result)
+      result['docid'].split(' ').last
     end
   end
 

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -169,6 +169,7 @@ describe Tanker do
         {
           :__any     => "#{$frozen_moment.to_i} . Last Name . Name",
           :__type    => 'Person',
+          :__id      => 1,
           :name      => 'Name',
           :last_name => 'Last Name',
           :timestamp => $frozen_moment.to_i
@@ -194,6 +195,7 @@ describe Tanker do
             :fields => {
               :__any     => "#{$frozen_moment.to_i} . Last Name . Name",
               :__type    => 'Person',
+              :__id      => 1,
               :name      => 'Name',
               :last_name => 'Last Name',
               :timestamp => $frozen_moment.to_i

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -63,8 +63,10 @@ describe Tanker do
         {
           "matches" => 1,
           "results" => [{
-            "docid" => Person.new.it_doc_id,
-            "name"  => 'pedro'
+            "docid"  => Person.new.it_doc_id,
+            "name"   => 'pedro',
+            "__type" => 'Person',
+            "__id"   => '1'
           }],
           "search_time" => 1
         }
@@ -85,7 +87,7 @@ describe Tanker do
     it 'should be able to use multi-value query phrases' do
       Person.tanker_index.should_receive(:search).with(
         "__any:(hey! location_id:(1) location_id:(2)) __type:(Person)",
-        {:start => 0, :len => 10}
+        {:start => 0, :len => 10, :fetch => "__type,__id"}
       ).and_return({'results' => [], 'matches' => 0})
 
       collection = Person.search_tank('hey!', :conditions => {:location_id => [1,2]})
@@ -96,7 +98,8 @@ describe Tanker do
         "__any:(hey!) __type:(Person)",
         { :start => 0,
           :len => 10,
-          :filter_function2 => "0:10,20:40"
+          :filter_function2 => "0:10,20:40",
+          :fetch => "__type,__id"
         }
       ).and_return({'results' => [], 'matches' => 0})
 
@@ -110,7 +113,8 @@ describe Tanker do
         "__any:(hey!) __type:(Person)",
         { :start => 0,
           :len => 10,
-          :filter_docvar3 => "*:7,80:100"
+          :filter_docvar3 => "*:7,80:100",
+          :fetch => "__type,__id"
         }
       ).and_return({'results' => [], 'matches' => 0})
 
@@ -127,12 +131,16 @@ describe Tanker do
         {
           "matches" => 2,
           "results" => [{
-            "docid" => 'Dog 7',
-            "name"  => 'fido'
+            "docid"  => 'Dog 7',
+            "name"   => 'fido',
+            "__type" => 'Dog',
+            "__id"   => '7'
           },
           {
-            "docid" => 'Cat 9',
-            "name"  => 'fluffy'
+            "docid"  => 'Cat 9',
+            "name"   => 'fluffy',
+            "__type" => 'Cat',
+            "__id"   => '9'
           }],
           "search_time" => 1
         }


### PR DESCRIPTION
For our use case, splitting the IndexTank document ID doesn't work, because we prefix it with the name of the database the corresponding record is stored in. We could still use the heuristic of the last "word" of the document ID being the corresponding ActiveRecord ID, but that seems a bit brittle.

Anyway, I modified Tanker to add an "__id" field to indexed models, and updated searching to leverage this new field as well as the already existing "__type" field when instantiating models. No new tests seemed necessary, but I have modified the existing ones where necessary.

(Also, I added the json gem to the Gemfile, for Ruby 1.8.7 compatiblity.)
