### PR TITLE
Remove single-class results-instantiation case

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "http://rubygems.org"
 
 gem 'jeweler'
+gem 'json', '>= 1.5.1'
 gem 'will_paginate', '>= 2.3.15'
 
 group :test do

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -125,20 +125,14 @@ module Tanker
           acc
         end
 
-        if 1 == id_map.size # check for simple case, just one model involved
-          klass = constantize(id_map.keys.first)
-          # eager-load and return just this model's records
-          klass.find(id_map.values.flatten)
-        else # complex case, multiple models involved
-          id_map.each do |klass, ids|
-            # replace the id list with an eager-loaded list of records for this model
-            id_map[klass] = constantize(klass).find(ids)
-          end
-          # return them in order
-          results.map do |result|
-            model, id = result["__type"], result["__id"]
-            id_map[model].detect {|record| id.to_i == record.id }
-          end
+        id_map.each do |klass, ids|
+          # replace the id list with an eager-loaded list of records for this model
+          id_map[klass] = constantize(klass).find(ids)
+        end
+        # return them in order
+        results.map do |result|
+          model, id = result["__type"], result["__id"]
+          id_map[model].detect {|record| id.to_i == record.id }
         end
       end
 

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -63,8 +63,10 @@ describe Tanker do
         {
           "matches" => 1,
           "results" => [{
-            "docid" => Person.new.it_doc_id,
-            "name"  => 'pedro'
+            "docid"  => Person.new.it_doc_id,
+            "name"   => 'pedro',
+            "__type" => 'Person',
+            "__id"   => '1'
           }],
           "search_time" => 1
         }
@@ -85,7 +87,7 @@ describe Tanker do
     it 'should be able to use multi-value query phrases' do
       Person.tanker_index.should_receive(:search).with(
         "__any:(hey! location_id:(1) location_id:(2)) __type:(Person)",
-        {:start => 0, :len => 10}
+        {:start => 0, :len => 10, :fetch => "__type,__id"}
       ).and_return({'results' => [], 'matches' => 0})
 
       collection = Person.search_tank('hey!', :conditions => {:location_id => [1,2]})
@@ -96,7 +98,8 @@ describe Tanker do
         "__any:(hey!) __type:(Person)",
         { :start => 0,
           :len => 10,
-          :filter_function2 => "0:10,20:40"
+          :filter_function2 => "0:10,20:40",
+          :fetch => "__type,__id"
         }
       ).and_return({'results' => [], 'matches' => 0})
 
@@ -110,7 +113,8 @@ describe Tanker do
         "__any:(hey!) __type:(Person)",
         { :start => 0,
           :len => 10,
-          :filter_docvar3 => "*:7,80:100"
+          :filter_docvar3 => "*:7,80:100",
+          :fetch => "__type,__id"
         }
       ).and_return({'results' => [], 'matches' => 0})
 
@@ -127,12 +131,16 @@ describe Tanker do
         {
           "matches" => 2,
           "results" => [{
-            "docid" => 'Dog 7',
-            "name"  => 'fido'
+            "docid"  => 'Dog 7',
+            "name"   => 'fido',
+            "__type" => 'Dog',
+            "__id"   => '7'
           },
           {
-            "docid" => 'Cat 9',
-            "name"  => 'fluffy'
+            "docid"  => 'Cat 9',
+            "name"   => 'fluffy',
+            "__type" => 'Cat',
+            "__id"   => '9'
           }],
           "search_time" => 1
         }


### PR DESCRIPTION
ActiveRecord#find, when given an array of ids, doesn't necessarily return those results in the order they occur in the array. I just removed the if/else block, since the default code does the right thing.
