### PR TITLE
Multiple tankits

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "http://rubygems.org"
 
 gem 'jeweler'
+gem 'json', '>= 1.5.1'
 gem 'will_paginate', '>= 2.3.15'
 
 group :test do

--- a/README.rdoc
+++ b/README.rdoc
@@ -177,7 +177,56 @@ IndexTank and the Tanker gem support native geographic calculations. All you nee
                       :function => 1,
                       :filter_functions => {2 => [['*', 50]]})
 
+== Extend your index definitions
 
+If you have a bunch of models with a lot of overlapping indexed fields,
+variables, or categories, you might want to abstract those out into a module
+that you can include and then extend in the including classes. Something like:
+
+    module TankerDefaults
+      def self.included(base)
+        base.send(:include, ::Tanker) # include the actual Tanker module
+
+        # provide a default index name
+        base.tankit 'my_index' do
+          # index some common fields
+          indexes :tag_list
+
+          # set some common variables
+          variables do
+            {
+              0 => view_count
+              1 => foo
+            }
+          end
+        end
+      end
+    end
+
+    class SuperModel
+      include TankerDefaults
+
+      # no need to respecify the index if it's the same
+      # (but you can override it)
+      tankit do
+        # `indexes :tag_list` is inherited
+        indexes :name
+        indexes :boyfriend_names do
+          boyfriends.map(&:name)
+        end
+
+        # set some more specific variables
+        variables do
+          {
+            # `0 => view_count` is inherited
+            1 => iq,                 # overwrites "foo"
+            2 => endorsements.count  # adds new variables
+          }
+        end
+      end
+    end
+
+You currently can't remove previously defined stuff, though.
 
 == Reindex your data
 

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -273,6 +273,7 @@ module Tanker
 
       data[:__any] = data.values.sort_by{|v| v.to_s}.join " . "
       data[:__type] = self.class.name
+      data[:__id] = self.id
 
       data
     end

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -119,7 +119,8 @@ module Tanker
         return [] if results.empty?
 
         id_map = results.inject({}) do |acc, result|
-          model, id = result["__type"], result["__id"]
+          model = result["__type"]
+          id = constantize(model).tanker_parse_doc_id(result)
           acc[model] ||= []
           acc[model] << id.to_i
           acc
@@ -136,7 +137,8 @@ module Tanker
           end
           # return them in order
           results.map do |result|
-            model, id = result["__type"], result["__id"]
+            model = result["__type"]
+            id = constantize(model).tanker_parse_doc_id(result)
             id_map[model].detect {|record| id.to_i == record.id }
           end
         end
@@ -190,6 +192,10 @@ module Tanker
         puts "Indexed #{batch.size} records   #{(idx * options[:batch_size]) + batch.size}/#{record_size}"
       end
       puts "Indexed #{record_size} #{self} records in #{Time.now - timer} seconds"
+    end
+
+    def tanker_parse_doc_id(result)
+      result['docid'].split(' ').last
     end
   end
 

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -36,11 +36,12 @@ module Tanker
     end
 
     def included(klass)
+      configuration # raises error if not defined
+
       @included_in ||= []
       @included_in << klass
       @included_in.uniq!
 
-      configuration # raises error if not defined
       klass.send :include, InstanceMethods
       klass.extend ClassMethods
 

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -24,6 +24,7 @@ module Tanker
 
   class NotConfigured < StandardError; end
   class NoBlockGiven < StandardError; end
+  class NoIndexName < StandardError; end
 
   autoload :Configuration, 'tanker/configuration'
   extend Configuration
@@ -153,7 +154,7 @@ module Tanker
 
     def tankit(name = nil, &block)
       if block_given?
-        raise(StandardError, 'Please provide an index name') if name.nil? && self.tanker_config.nil?
+        raise(NoIndexName, 'Please provide an index name') if name.nil? && self.tanker_config.nil?
 
         self.tanker_config ||= ModelConfig.new(name, Proc.new)
         name ||= self.tanker_config.index_name

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -125,20 +125,14 @@ module Tanker
           acc
         end
 
-        if 1 == id_map.size # check for simple case, just one model involved
-          klass = constantize(id_map.keys.first)
-          # eager-load and return just this model's records
-          klass.find(id_map.values.flatten)
-        else # complex case, multiple models involved
-          id_map.each do |klass, ids|
-            # replace the id list with an eager-loaded list of records for this model
-            id_map[klass] = constantize(klass).find(ids)
-          end
-          # return them in order
-          results.map do |result|
-            model, id = result["__type"], result["__id"]
-            id_map[model].detect {|record| id.to_i == record.id }
-          end
+        id_map.each do |klass, ids|
+          # replace the id list with an eager-loaded list of records for this model
+          id_map[klass] = constantize(klass).find(ids)
+        end
+        # return them in order
+        results.map do |result|
+          model, id = result["__type"], result["__id"]
+          id_map[model].detect {|record| id.to_i == record.id }
         end
       end
 

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -165,8 +165,10 @@ module Tanker
           self.tanker_config.indexes << [key, value]
         end
 
-        self.tanker_config.variables do
-          instance_exec &config.variables.first
+        unless config.variables.empty?
+          self.tanker_config.variables do
+            instance_exec &config.variables.first
+          end
         end
       else
         raise(NoBlockGiven, 'Please provide a block')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,10 +12,6 @@ end
 
 Tanker.configuration = {:url => 'http://api.indextank.com'}
 
-class Dummy
-
-end
-
 $frozen_moment = Time.now
 
 class Person

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -139,6 +139,32 @@ describe Tanker do
       dummy_instance = @dummy_class.new
       dummy_instance.tanker_index_options[:variables].should == { 0 => 1.618034, 1 => 2.7182818 }
     end
+
+    it "can be initially defined in one module and extended in the including class" do
+      dummy_module = Module.new do
+        def self.included(base)
+          base.send :include, Tanker
+
+          base.tankit 'dummy index' do
+            indexes :name
+          end
+        end
+      end
+
+      dummy_class = Class.new do
+        include dummy_module
+
+        tankit 'another index' do
+          indexes :email
+        end
+      end
+
+      dummy_instance = dummy_class.new
+      dummy_instance.tanker_config.index_name.should == 'another index'
+      Hash[*dummy_instance.tanker_config.indexes.flatten].keys.should == [:name, :email]
+
+      Tanker.instance_variable_set(:@included_in, Tanker.included_in - [dummy_class])
+    end
   end
 
   describe 'tanker instance' do

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -169,6 +169,7 @@ describe Tanker do
         {
           :__any     => "#{$frozen_moment.to_i} . Last Name . Name",
           :__type    => 'Person',
+          :__id      => 1,
           :name      => 'Name',
           :last_name => 'Last Name',
           :timestamp => $frozen_moment.to_i
@@ -194,6 +195,7 @@ describe Tanker do
             :fields => {
               :__any     => "#{$frozen_moment.to_i} . Last Name . Name",
               :__type    => 'Person',
+              :__id      => 1,
               :name      => 'Name',
               :last_name => 'Last Name',
               :timestamp => $frozen_moment.to_i

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -63,8 +63,10 @@ describe Tanker do
         {
           "matches" => 1,
           "results" => [{
-            "docid" => Person.new.it_doc_id,
-            "name"  => 'pedro'
+            "docid"  => Person.new.it_doc_id,
+            "name"   => 'pedro',
+            "__type" => 'Person',
+            "__id"   => '1'
           }],
           "search_time" => 1
         }
@@ -85,7 +87,7 @@ describe Tanker do
     it 'should be able to use multi-value query phrases' do
       Person.tanker_index.should_receive(:search).with(
         "__any:(hey! location_id:(1) location_id:(2)) __type:(Person)",
-        {:start => 0, :len => 10}
+        {:start => 0, :len => 10, :fetch => "__type,__id"}
       ).and_return({'results' => [], 'matches' => 0})
 
       collection = Person.search_tank('hey!', :conditions => {:location_id => [1,2]})
@@ -96,7 +98,8 @@ describe Tanker do
         "__any:(hey!) __type:(Person)",
         { :start => 0,
           :len => 10,
-          :filter_function2 => "0:10,20:40"
+          :filter_function2 => "0:10,20:40",
+          :fetch => "__type,__id"
         }
       ).and_return({'results' => [], 'matches' => 0})
 
@@ -110,7 +113,8 @@ describe Tanker do
         "__any:(hey!) __type:(Person)",
         { :start => 0,
           :len => 10,
-          :filter_docvar3 => "*:7,80:100"
+          :filter_docvar3 => "*:7,80:100",
+          :fetch => "__type,__id"
         }
       ).and_return({'results' => [], 'matches' => 0})
 
@@ -127,12 +131,16 @@ describe Tanker do
         {
           "matches" => 2,
           "results" => [{
-            "docid" => 'Dog 7',
-            "name"  => 'fido'
+            "docid"  => 'Dog 7',
+            "name"   => 'fido',
+            "__type" => 'Dog',
+            "__id"   => '7'
           },
           {
-            "docid" => 'Cat 9',
-            "name"  => 'fluffy'
+            "docid"  => 'Cat 9',
+            "name"   => 'fluffy',
+            "__type" => 'Cat',
+            "__id"   => '9'
           }],
           "search_time" => 1
         }

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -1,22 +1,24 @@
 require File.expand_path(File.join(File.dirname(__FILE__), 'spec_helper'))
 
-class Dummy
-  include Tanker
-
-  tankit 'dummy index' do
-    indexes :name
-  end
-
-end
-
-
 describe Tanker::Utilities do
 
+  before :each do
+    @dummy_class = Class.new do
+      include Tanker
+    end
+  end
+
+  after :each do
+    Tanker.instance_variable_set(:@included_in, Tanker.included_in - [@dummy_class])
+  end
+
   it "should get the models where Tanker module was included" do
-    (Tanker::Utilities.get_model_classes - [Dummy, Person, Dog, Cat]).should == []
+    (Tanker::Utilities.get_model_classes - [@dummy_class, Person, Dog, Cat]).should == []
   end
 
   it "should get the available indexes" do
+    @dummy_class.send(:tankit, 'dummy index') do
+    end
     Tanker::Utilities.get_available_indexes.should == ["people", "animals", "dummy index"]
   end
 


### PR DESCRIPTION
The motivation for this is that I have a lot of classes getting indexed that have a lot of very similar fields that I wanted to generalize into a module, and then include and extend in the ActiveRecord classes. Here's the general idea (straight from the stuff I added to the README).

```
module TankerDefaults
  def self.included(base)
    base.send(:include, ::Tanker) # include the actual Tanker module

    # provide a default index name
    base.tankit 'my_index' do
      # index some common fields
      indexes :tag_list

      # set some common variables
      variables do
        {
          0 => view_count
          1 => foo
        }
      end
    end
  end
end

class SuperModel
  include TankerDefaults

  # no need to respecify the index if it's the same
  # (but you can override it)
  tankit do
    # `indexes :tag_list` is inherited
    indexes :name
    indexes :boyfriend_names do
      boyfriends.map(&:name)
    end

    # set some more specific variables
    variables do
      {
        # `0 => view_count` is inherited
        1 => iq,                 # overwrites "foo"
        2 => endorsements.count  # adds new variables
      }
    end
  end
end
```
