### PR TITLE
ThinkingSphinx's "where"

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -191,7 +191,7 @@ If your IndexTank indexes have faceting enabled, you can do this:
         # return a hash of category/value pairs
         categories do
           {
-            'price_range' => (price > 5) ? 'expensive' : 'cheap'
+            'price_range' => (price > 5 ? 'expensive' : 'cheap')
           }
         end
       end
@@ -203,6 +203,21 @@ To retrieve facets in a search:
 
     # @facets =
     #   { 'price_range' => { 'expensive' => 93, 'cheap' => 47 } }
+
+At some point you will probably also want to filter what categories to search.
+That's faceted searching, after all!
+
+    # search only cheap parts:
+    @parts = Part.search_tank('widget', :category_filters => { 'price_range' => 'cheap' })
+
+    # highly contrived, but to show how you could filter multiple values for a
+    # given category:
+    @parts = Part.search_tank('widget', :category_filters => { 'price_range' => ['cheap', 'expensive'] })
+
+    # or multiple categories:
+    @parts = Part.search_tank('widget', :category_filters => { 'price_range' => ['cheap', 'expensive'],
+                                                               'type' => 'Part' })
+
 
 == Extend your index definitions
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -177,6 +177,33 @@ IndexTank and the Tanker gem support native geographic calculations. All you nee
                       :function => 1,
                       :filter_functions => {2 => [['*', 50]]})
 
+== Categories and faceted search example
+
+If your IndexTank indexes have faceting enabled, you can do this:
+
+    class Part < ActiveRecord::Base
+      include Tanker
+
+      tankit 'index' do
+        indexes :brand
+        indexes :part_number
+
+        # return a hash of category/value pairs
+        categories do
+          {
+            'price_range' => (price > 5) ? 'expensive' : 'cheap'
+          }
+        end
+      end
+    end
+
+To retrieve facets in a search:
+
+    @parts, @facets = Part.search_tank('widget', :facets => true)
+
+    # @facets =
+    #   { 'price_range' => { 'expensive' => 93, 'cheap' => 47 } }
+
 == Extend your index definitions
 
 If you have a bunch of models with a lot of overlapping indexed fields,
@@ -199,6 +226,13 @@ that you can include and then extend in the including classes. Something like:
               1 => foo
             }
           end
+
+          # set some common categories
+          categories do
+            {
+              "type" => self.class.name
+            }
+          end
         end
       end
     end
@@ -215,7 +249,6 @@ that you can include and then extend in the including classes. Something like:
           boyfriends.map(&:name)
         end
 
-        # set some more specific variables
         variables do
           {
             # `0 => view_count` is inherited
@@ -223,6 +256,8 @@ that you can include and then extend in the including classes. Something like:
             2 => endorsements.count  # adds new variables
           }
         end
+
+        # and the same can be done with categories
       end
     end
 

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -236,6 +236,11 @@ module Tanker
       @functions
     end
 
+    def categories(&block)
+      @categories = block if block
+      @categories
+    end
+
     def index
       @index ||= Tanker.api.get_index(index_name)
     end
@@ -255,6 +260,10 @@ module Tanker
 
     def tanker_variables
       tanker_config.variables
+    end
+
+    def tanker_categories
+      tanker_config.categories
     end
 
     # update a create instance from index tank
@@ -297,6 +306,10 @@ module Tanker
         options[:variables] = tanker_variables.inject({}) do |hash, variables|
           hash.merge(instance_exec(&variables))
         end
+      end
+
+      if tanker_categories
+        options[:categories] = instance_exec(&tanker_categories)
       end
 
       options

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -99,6 +99,9 @@ module Tanker
         end
       end
 
+      # IndexTank expects a JSON_formatted map in the GET query variable
+      options[:category_filters] = options[:category_filters].to_json if options[:category_filters]
+
       options[:fetch] = "__type,__id"
 
       query = "__any:(#{query.to_s}) __type:(#{models.map(&:name).join(' OR ')})"

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -69,6 +69,8 @@ module Tanker
       index    = models.first.tanker_index
       query    = query.join(' ') if Array === query
 
+      return_facets = options.delete(:facets)
+
       if (index_names = models.map(&:tanker_config).map(&:index_name).uniq).size > 1
         raise "You can't search across multiple indexes in one call (#{index_names.inspect})"
       end
@@ -112,6 +114,8 @@ module Tanker
           pager.total_entries = results["matches"]
         end
       end
+
+      return_facets ? [@entries, (results['facets'] || {})] : @entries
     end
 
     protected

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -69,8 +69,6 @@ module Tanker
       index    = models.first.tanker_index
       query    = query.join(' ') if Array === query
 
-      return_facets = options.delete(:facets)
-
       if (index_names = models.map(&:tanker_config).map(&:index_name).uniq).size > 1
         raise "You can't search across multiple indexes in one call (#{index_names.inspect})"
       end
@@ -118,7 +116,9 @@ module Tanker
         end
       end
 
-      return_facets ? [@entries, (results['facets'] || {})] : @entries
+      @entries.extend ResultsMethods
+      @entries.results = results
+      @entries
     end
 
     protected
@@ -330,6 +330,14 @@ module Tanker
     # create a unique index based on the model name and unique id
     def it_doc_id
       self.class.name + ' ' + self.id.to_s
+    end
+  end
+
+  module ResultsMethods
+    attr_accessor :results
+
+    def facets
+      @results['facets']
     end
   end
 end

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -170,9 +170,11 @@ module Tanker
           self.tanker_config.indexes << [key, value]
         end
 
-        unless config.variables.empty?
-          self.tanker_config.variables do
-            instance_exec &config.variables.first
+        %w[variables categories].each do |method|
+          unless config.send(method).empty?
+            self.tanker_config.send(method) do
+              instance_exec &config.send(method).first
+            end
           end
         end
       else
@@ -222,6 +224,7 @@ module Tanker
       @indexes    = []
       @variables  = []
       @functions  = {}
+      @categories = []
       instance_exec &block
     end
 
@@ -241,7 +244,7 @@ module Tanker
     end
 
     def categories(&block)
-      @categories = block if block
+      @categories << block if block
       @categories
     end
 
@@ -312,8 +315,10 @@ module Tanker
         end
       end
 
-      if tanker_categories
-        options[:categories] = instance_exec(&tanker_categories)
+      unless tanker_categories.empty?
+        options[:categories] = tanker_categories.inject({}) do |hash, categories|
+          hash.merge(instance_exec(&categories))
+        end
       end
 
       options

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -70,6 +70,18 @@ describe Tanker do
       dummy_instance.tanker_config.indexes.any? {|field, block| field == :class_name }.should == true
     end
 
+    it 'should set categories' do
+      @dummy_class.send(:tankit, 'dummy index') do
+        categories do
+          { 'foo' => foo }
+        end
+      end
+
+      dummy_instance = @dummy_class.new
+      dummy_instance.should_receive(:foo).and_return('bar')
+      dummy_instance.instance_exec(&dummy_instance.tanker_config.categories).should == { 'foo' => 'bar' }
+    end
+
     it 'should overwrite the previous index name if provided' do
       @dummy_class.send(:tankit, 'first index') do
       end
@@ -165,20 +177,6 @@ describe Tanker do
 
       Tanker.instance_variable_set(:@included_in, Tanker.included_in - [dummy_class])
     end
-  end
-
-  it 'should set categories' do
-    Tanker.configuration = {:url => 'http://api.indextank.com'}
-    Dummy.send(:include, Tanker)
-    Dummy.send(:tankit, 'dummy index') do
-      categories do
-        { 'foo' => foo }
-      end
-    end
-
-    dummy_instance = Dummy.new
-    dummy_instance.should_receive(:foo).and_return('bar')
-    dummy_instance.instance_exec(&dummy_instance.tanker_config.categories).should == { 'foo' => 'bar' }
   end
 
   describe 'tanker instance' do

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -351,5 +351,58 @@ describe Tanker do
       person.delete_tank_indexes
     end
 
+    describe 'facets' do
+      it 'search should return a two-element array when ":facets => true" option is set' do
+        Person.tanker_index.should_receive(:search).and_return({
+          "matches" => 1,
+          "results" => [
+            {"docid" => "Person 1", "__type" => "Person", "__id" => "1"}
+          ],
+          "facets" => {
+            "job" => {
+              "tiny dancer" => 1
+            }
+          }
+        })
+        Person.should_receive(:find).and_return([Person.new])
+
+        Person.search_tank('hey!', :facets => true).size.should == 2
+      end
+
+      it '":facets => true" search results first element are the instantiated models' do
+        Person.tanker_index.should_receive(:search).and_return({
+          "matches" => 1,
+          "results" => [
+            {"docid" => "Person 1", "__type" => "Person", "__id" => "1"}
+          ],
+          "facets" => {
+            "job" => {
+              "tiny dancer" => 1
+            }
+          }
+        })
+        Person.should_receive(:find).and_return([Person.new])
+
+        Person.search_tank('hey!', :facets => true).first.should be_an_instance_of(WillPaginate::Collection)
+      end
+
+      it '":facets => true" search results second element is a hash of the facets' do
+        Person.tanker_index.should_receive(:search).and_return({
+          "matches" => 1,
+          "results" => [
+            {"docid" => "Person 1", "__type" => "Person", "__id" => "1"}
+          ],
+          "facets" => {
+            "job" => {
+              "tiny dancer" => 1
+            }
+          }
+        })
+        Person.should_receive(:find).and_return([Person.new])
+
+        Person.search_tank('hey!', :facets => true).last.should == { "job" => { "tiny dancer" => 1 } }
+      end
+    end
+
   end
 end

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -422,6 +422,15 @@ describe Tanker do
 
         Person.search_tank('hey!', :facets => true).last.should == { "job" => { "tiny dancer" => 1 } }
       end
+
+      it ':category_filters option gets passed to client as JSON' do
+        Person.tanker_index.should_receive(:search)
+          .with(anything, hash_including(:category_filters => '{"type":"Person"}'))
+          .and_return(nil)
+        Tanker.stub!(:instantiate_results => [Person.new])
+
+        Person.search_tank('hey!', :category_filters => { 'type' => Person.name })
+      end
     end
 
   end

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -167,6 +167,20 @@ describe Tanker do
     end
   end
 
+  it 'should set categories' do
+    Tanker.configuration = {:url => 'http://api.indextank.com'}
+    Dummy.send(:include, Tanker)
+    Dummy.send(:tankit, 'dummy index') do
+      categories do
+        { 'foo' => foo }
+      end
+    end
+
+    dummy_instance = Dummy.new
+    dummy_instance.should_receive(:foo).and_return('bar')
+    dummy_instance.instance_exec(&dummy_instance.tanker_config.categories).should == { 'foo' => 'bar' }
+  end
+
   describe 'tanker instance' do
     it 'should create an api instance' do
       Tanker.api.class.should == IndexTank::ApiClient

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -78,8 +78,8 @@ describe Tanker do
       end
 
       dummy_instance = @dummy_class.new
-      dummy_instance.should_receive(:foo).and_return('bar')
-      dummy_instance.instance_exec(&dummy_instance.tanker_config.categories).should == { 'foo' => 'bar' }
+      dummy_instance.stub!(:foo => "bar")
+      dummy_instance.tanker_index_options[:categories] == { 'foo' => 'bar' }
     end
 
     it 'should overwrite the previous index name if provided' do
@@ -150,6 +150,28 @@ describe Tanker do
 
       dummy_instance = @dummy_class.new
       dummy_instance.tanker_index_options[:variables].should == { 0 => 1.618034, 1 => 2.7182818 }
+    end
+
+    it 'should merge with previously defined categories' do
+      @dummy_class.send(:tankit, 'dummy index') do
+        categories do
+          {
+            "undies" => "boxers",
+            "cheese" => "cheddar"
+          }
+        end
+      end
+      @dummy_class.send(:tankit, 'dummy index') do
+        categories do
+          {
+            "undies" => "briefs",
+            "drives" => "prius"
+          }
+        end
+      end
+
+      dummy_instance = @dummy_class.new
+      dummy_instance.tanker_index_options[:categories].should == { "undies" => "briefs", "cheese" => "cheddar", "drives" => "prius" }
     end
 
     it "can be initially defined in one module and extended in the including class" do

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -372,7 +372,7 @@ describe Tanker do
     end
 
     describe 'facets' do
-      it 'search should return a two-element array when ":facets => true" option is set' do
+      it 'search results object should respond to :facets' do
         Person.tanker_index.should_receive(:search).and_return({
           "matches" => 1,
           "results" => [
@@ -386,10 +386,11 @@ describe Tanker do
         })
         Person.should_receive(:find).and_return([Person.new])
 
-        Person.search_tank('hey!', :facets => true).size.should == 2
+        results = Person.search_tank('hey!')
+        results.should respond_to :facets
       end
 
-      it '":facets => true" search results first element are the instantiated models' do
+      it 'facets is a nested hash of category, values, and counts' do
         Person.tanker_index.should_receive(:search).and_return({
           "matches" => 1,
           "results" => [
@@ -403,24 +404,8 @@ describe Tanker do
         })
         Person.should_receive(:find).and_return([Person.new])
 
-        Person.search_tank('hey!', :facets => true).first.should be_an_instance_of(WillPaginate::Collection)
-      end
-
-      it '":facets => true" search results second element is a hash of the facets' do
-        Person.tanker_index.should_receive(:search).and_return({
-          "matches" => 1,
-          "results" => [
-            {"docid" => "Person 1", "__type" => "Person", "__id" => "1"}
-          ],
-          "facets" => {
-            "job" => {
-              "tiny dancer" => 1
-            }
-          }
-        })
-        Person.should_receive(:find).and_return([Person.new])
-
-        Person.search_tank('hey!', :facets => true).last.should == { "job" => { "tiny dancer" => 1 } }
+        results = Person.search_tank('hey!')
+        results.facets.should == { 'job' => { 'tiny dancer' => 1 } }
       end
 
       it ':category_filters option gets passed to client as JSON' do


### PR DESCRIPTION
I need to be able to filter which documents get indexed by Tanker. ThinkingSphinx uses a `where` method, which acts more or less like a named scope.

In its current state, the `where` method I implemented for the `tankit` DSL only specifies a scope that gets automatically called in `tanker_reindex` (which, awesomely enough, already accepts a `:scope` option).

It works, but I'm not exactly satisfied with the approach, so consider this pull request an attempt to start a discussion around the topic.
