### PR TITLE
Added :pagination_backend setting and Kaminari support via that setting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,8 @@ gem 'json', '>= 1.5.1'
 gem 'will_paginate', '>= 2.3.15'
 
 group :test do
-  gem 'rspec', '>= 2.5.0' 
+  gem 'rspec', '>= 2.5.0'
+  gem 'kaminari'
 end
 
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -2,8 +2,9 @@
 
 IndexTank is a great search indexing service, this gem tries to make
 that any orm stays in sync with IndexTank easily. It has a simple
-yet powerful approach to integrate IndexTank with any orm and
-also supports pagination using +will_paginate/collection+.
+yet powerful approach to integrate IndexTank with any ORM and
+also supports pagination using {WillPaginate}[https://github.com/mislav/will_paginate] (default)
+or {Kaminari}[https://github.com/amatsuda/kaminari].
 
 Very little is needed to make it work,
 basically, all you need is that the orm instance respond to +id+ and any attributes
@@ -25,13 +26,25 @@ If you're using Rails, config/initializers/tanker.rb is a good place for this:
 
     YourAppName::Application.config.index_tank_url = 'http://:xxxxxxxxx@xxxxx.api.indextank.com'
 
-If you are not using rails you can put this somewhere before you load your modesl
+If you are not using rails you can put this somewhere before you load your models
 
     Tanker.configuration = {:url => 'http://:xxxxxxxxx@xxxxx.api.indextank.com' }
 
 You would probably want to have fancier configuration depending on
 your environment. Be sure to copy and paste the correct url provided
 by the IndexTank Dashboard
+
+=== Pagination
+
+WillPaginate is used by default and you don't have to add any extra settings to use that. If you
+want to use Kaminari you have to add the following:
+
+    YourAppName::Application.config.index_tank_url = 'http://...'
+    YourAppName::Application.config.tanker_pagination_backend = :kaminari  
+
+or
+
+    Tanker.configuration = {:url => 'http://...', :pagination_backend => :kaminari }
 
 == Example
     
@@ -117,7 +130,8 @@ Search with query variables
 
 Paginate Results
 
-    <% will_paginate(@topics) %>
+    <%= will_paginate @topics %> for WillPaginate 
+    <%= paginate @topics %> for Kaminari
 
 Disable pagination of search results
 

--- a/lib/tanker/configuration.rb
+++ b/lib/tanker/configuration.rb
@@ -1,15 +1,14 @@
 module Tanker
-
   module Configuration
-
     def configuration
       @@configuration || raise(NotConfigured, "Please configure Tanker. Set Tanker.configuration = {:url => ''}")
     end
 
     def configuration=(new_configuration)
-      @@configuration = new_configuration
+      # the default pagination backend is WillPaginate
+      @@configuration = new_configuration.tap do |_config|
+        _config.replace({ :pagination_backend => :will_paginate }.merge(_config)) if _config.is_a?(Hash)
+      end
     end
-
   end
-
 end

--- a/lib/tanker/paginated_array.rb
+++ b/lib/tanker/paginated_array.rb
@@ -1,0 +1,29 @@
+unless defined?(Kaminari)
+  raise(Tanker::BadConfiguration, "Tanker: Please add 'kaminari' to your Gemfile to use kaminari pagination backend")
+end
+
+module Tanker
+  class KaminariPaginatedArray < Array
+    include ::Kaminari::ConfigurationMethods::ClassMethods
+    include ::Kaminari::PageScopeMethods
+
+    attr_reader :limit_value, :offset_value, :total_count
+
+    def initialize(original_array, limit_val = default_per_page, offset_val, total_count)
+      @limit_value, @offset_value, @total_count = limit_val, offset_val, total_count
+      super(original_array)
+    end
+
+    def page(num = 1)
+      self
+    end
+
+    def limit(num)
+      self
+    end
+
+    def current_page
+      offset_value+1
+    end
+  end
+end

--- a/lib/tanker/railtie.rb
+++ b/lib/tanker/railtie.rb
@@ -2,18 +2,27 @@ require 'rails'
 
 module Tanker
   class Railtie < Rails::Railtie
-    config.index_tank_url = ''
-    
+    config.index_tank_url = nil
+    config.tanker_pagination_backend = nil
+
     initializer "tanker.boot" do
-      Tanker.configuration = {:url => config.index_tank_url }
+      setup_tanker_configuration
     end
-    
+
     config.after_initialize do
-      Tanker.configuration = {:url => config.index_tank_url }
+      setup_tanker_configuration
     end
 
     rake_tasks do
       load "tanker/tasks/tanker.rake"
+    end
+
+  private
+    def setup_tanker_configuration
+      Tanker.configuration = {}.tap do |_new_conf|
+        _new_conf[:url] = config.index_tank_url if config.index_tank_url
+        _new_conf[:pagination_backend] = config.tanker_pagination_backend if config.tanker_pagination_backend
+      end
     end
   end
 end


### PR DESCRIPTION
Hey, here some more stuff.. =) Kaminari support - https://github.com/amatsuda/kaminari

Added kaminari to the test group in the Gemfile. I don't think we want to put kaminari as a requirment as it depends on rails 3, its only loaded if the the pagination setting has been set to kaminari and an error will be raised if it has not been required before (ie. in the rails app using tanker). 
