### PR TITLE
Remove defaults for optional args for 1.8.7 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem 'kaminari'
 
 group :test do 
   gem 'rspec', '>= 2.5.0'
-  gem 'ruby-debug19'
   gem 'activerecord', '>= 3.0.7'
   gem 'sqlite3'
 end

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -232,7 +232,7 @@ module Tanker
 
         self.tanker_config.index_name = name
 
-        config = ModelConfig.new(name, block)
+        config = ModelConfig.new(name, {}, block)
         config.indexes.each do |key, value|
           self.tanker_config.indexes << [key, value]
         end
@@ -286,7 +286,7 @@ module Tanker
     attr_accessor :index_name
     attr_accessor :options
 
-    def initialize(index_name, options = {}, block)
+    def initialize(index_name, options, block)
       @index_name = index_name
       @options    = options
       @indexes    = []

--- a/lib/tanker/paginated_array.rb
+++ b/lib/tanker/paginated_array.rb
@@ -9,8 +9,9 @@ module Tanker
 
     attr_reader :limit_value, :offset_value, :total_count
 
-    def initialize(original_array, limit_val = default_per_page, offset_val, total_count)
-      @limit_value, @offset_value, @total_count = limit_val, offset_val, total_count
+    def initialize(original_array, limit_val, offset_val, total_count)
+      @limit_value = limit_val || default_per_page
+      @offset_value, @total_count = offset_val, total_count
       super(original_array)
     end
 


### PR DESCRIPTION
Also remove ruby-debug19 for 1.8.7 compatibility.

This is my first pull request, so use the code, use pieces, ignore it, or whatever is appropriate. I wasn't sure of the correct style for the optional arguments. These changes made everything work ok in my project on 1.8.7.  I didn't review all code, so there may be other 1.9.2 stuff still lurking.  

Also, all specs pass on 1.8.7 except for one, which I couldn't figure out how to fix.

```
  1) Tanker Kaminari support should be able to return Kaminari compatible array for a search
     Failure/Error: array = Person.search_tank('hey!')
     NameError:
       uninitialized constant Tanker::KaminariPaginatedArray
     # ./spec/../lib/tanker.rb:153:in `paginate_results'
     # ./spec/../lib/tanker.rb:118:in `search'
     # ./spec/../lib/tanker.rb:251:in `search_tank'
     # ./spec/tanker_spec.rb:535
```
