### PR TITLE
Fix to make Kaminari tests pass on ruby 1.8.7

### DIFF
--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -487,7 +487,7 @@ describe Tanker do
     end
   end
 
-  describe "Kaminari support" do
+  describe "with Kaminari support" do
 
     before :all do
       Tanker.configuration = {:url => 'http://api.indextank.com', :pagination_backend => :kaminari}
@@ -495,6 +495,12 @@ describe Tanker do
 
     after :all do
       Tanker.configuration = {}
+    end
+
+    # Need to do this for tests to pass on 1.8.7. If not tanker.rb is
+    # reloaded Tanker::KaminariPaginatedArray const gets removed (!?)
+    before :each do
+      load 'tanker.rb'
     end
 
     it 'should raise error message if Kaminari gem is not required' do


### PR DESCRIPTION
In relation to issue #26
Don't know if I am missing something, but to me it looks like this needs to be done inorder for the "should be able to return Kaminari compatible array for a search" test to pass on 1.8.7. 

Just getting that NameError when running the tests, looks to be working when used in a rails3 app with 1.8.7.
