### PR TITLE
Make tanker work with scope of ActiveRecords

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -124,7 +124,7 @@ Search Topics
     @topics = Topic.search_tank('blah',  :conditions => {:tag_list => 'tag1'}) # Gets 2 results!
     @topics = Topic.search_tank('blah',  :conditions => {:title => 'Awesome', :tag_list => 'tag1'}) # Gets 1 result!
 
-Search with scope
+Search with scope (Only tested on ActiveRecord)
 
     @topics = Topic.awesome.search_tank('blah') # Gets 1 result!
     

--- a/README.rdoc
+++ b/README.rdoc
@@ -54,6 +54,9 @@ or
       
       # just include the Tanker module
       include Tanker
+      
+      # define a scope
+      scope :awesome, :conditions => {:title => 'Awesome'}
 
       # define the index by supplying the index name and the fields to index
       # this is the index name you create in the Index Tank dashboard
@@ -121,6 +124,10 @@ Search Topics
     @topics = Topic.search_tank('blah',  :conditions => {:tag_list => 'tag1'}) # Gets 2 results!
     @topics = Topic.search_tank('blah',  :conditions => {:title => 'Awesome', :tag_list => 'tag1'}) # Gets 1 result!
 
+Search with scope
+
+    @topics = Topic.awesome.search_tank('blah') # Gets 1 result!
+    
 Search with wildcards!
 
     @topics = Topic.search_tank('Awe*', :page => 1, :per_page => 10) # Gets 1 result!

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -141,10 +141,11 @@ module Tanker
           id_map[klass] = klass_const.where(klass_const.primary_key => ids)
         end
         # return them in order
-        results.map do |result|
+        results = results.map do |result|
           model, id = result["__type"], result["__id"]
           id_map[model].detect {|record| id == record.id.to_s }
         end
+        results.compact
       end
 
       def instantiate_results_from_results(index_result, fetch = false, snippets = false)

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -138,7 +138,11 @@ module Tanker
         id_map.each do |klass, ids|
           # replace the id list with an eager-loaded list of records for this model
           klass_const = constantize(klass)
-          id_map[klass] = klass_const.find_all_by_id(ids)
+          if klass_const.respond_to?('find_all_by_id') 
+            id_map[klass] = klass_const.find_all_by_id(ids)
+          else
+            id_map[klass] = klass_const.find(ids)
+          end  
         end
         # return them in order
         results = results.map do |result|

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -137,7 +137,8 @@ module Tanker
 
         id_map.each do |klass, ids|
           # replace the id list with an eager-loaded list of records for this model
-          id_map[klass] = constantize(klass).find(ids)
+          klass_const = constantize(klass)
+          id_map[klass] = klass_const.where(klass_const.primary_key => ids)
         end
         # return them in order
         results.map do |result|

--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -138,7 +138,7 @@ module Tanker
         id_map.each do |klass, ids|
           # replace the id list with an eager-loaded list of records for this model
           klass_const = constantize(klass)
-          id_map[klass] = klass_const.where(klass_const.primary_key => ids)
+          id_map[klass] = klass_const.find_all_by_id(ids)
         end
         # return them in order
         results = results.map do |result|

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -26,6 +26,8 @@ end
 class Product < ActiveRecord::Base
   include Tanker
 
+  scope :amazon, :conditions => {:href => "amazon"}
+
   tankit 'tanker_integration_tests' do
     indexes :name
     indexes :href, :category => true
@@ -260,5 +262,13 @@ describe 'An imaginary store' do
       @results.count.should == 3
     end
   end 
+  
+  describe 'on scope' do
+    it 'should return amazon product only', :focus => true do
+      results = Product.amazon.search_tank('decent')
+      results.should include(@samsung, @motorola)
+      results.should have_exactly(2).products
+    end
+  end
 end
 

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -229,7 +229,7 @@ describe Tanker do
         }
       )
 
-      Person.should_receive(:find).and_return(
+      Person.should_receive(:find_all_by_id).and_return(
       [Person.new]
       )
 
@@ -260,7 +260,7 @@ describe Tanker do
         }
       )
 
-      Person.should_receive(:find).with(['mystring1d', '1']).and_return(
+      Person.should_receive(:find_all_by_id).with(['mystring1d', '1']).and_return(
         [Person.new, Person.new]
       )
 
@@ -323,10 +323,10 @@ describe Tanker do
         }
       )
 
-      Dog.should_receive(:find).and_return(
+      Dog.should_receive(:find_all_by_id).and_return(
         [Dog.new(:name => 'fido', :id => 7)]
       )
-      Cat.should_receive(:find).and_return(
+      Cat.should_receive(:find_all_by_id).and_return(
         [Cat.new(:name => 'fluffy', :id => 9)]
       )
 
@@ -350,7 +350,7 @@ describe Tanker do
           }]
         })
 
-      Foo::Bar.should_receive(:find).and_return([stub(:id => 42)])
+      Foo::Bar.should_receive(:find_all_by_id).and_return([stub(:id => 42)])
 
       Foo::Bar.search_tank('bar')
     end
@@ -374,7 +374,7 @@ describe Tanker do
         }
       )
 
-      Person.should_receive(:find).with(['1', '2']).and_return(
+      Person.should_receive(:find_all_by_id).with(['1', '2']).and_return(
         [Person.new, Person.new]
       )
 
@@ -402,7 +402,7 @@ describe Tanker do
         }
       )
 
-      Person.should_receive(:find).with(['1', '2']).and_return(
+      Person.should_receive(:find_all_by_id).with(['1', '2']).and_return(
         [Person.new, Person.new]
       )
 
@@ -540,7 +540,7 @@ describe Tanker do
           "search_time" => 1
         }
       )
-      Person.should_receive(:find).and_return([Person.new])
+      Person.should_receive(:find_all_by_id).and_return([Person.new])
 
       lambda { Person.search_tank('test') }.should raise_error(Tanker::BadConfiguration)
     end
@@ -560,7 +560,7 @@ describe Tanker do
         }
       )
 
-      Person.should_receive(:find).and_return([Person.new])
+      Person.should_receive(:find_all_by_id).and_return([Person.new])
 
       array = Person.search_tank('hey!')
       array.class.should == Tanker::Pagination::Kaminari
@@ -570,4 +570,5 @@ describe Tanker do
       array.current_page.should == 1
     end
   end
+
 end


### PR DESCRIPTION
Use where condition instead of the find method to ignore the RecordNotFound errors when using search_tank under scope.
