### PR TITLE
Searching one model can return other models

### DIFF
--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -105,7 +105,7 @@ module Tanker
 
       search_on_fields = models.map{|model| model.tanker_config.indexes.map{|arr| arr[0]}.uniq}.flatten.uniq.join(":(#{query.to_s}) OR ")
 
-      query = "#{search_on_fields}:(#{query.to_s}) OR __any:(#{query.to_s}) __type:(#{models.map(&:name).map {|name| "\"#{name.split('::').join(' ')}\"" }.join(' OR ')})"
+      query = "(#{search_on_fields}:(#{query.to_s}) OR __any:(#{query.to_s})) __type:(#{models.map(&:name).map {|name| "\"#{name.split('::').join(' ')}\"" }.join(' OR ')})"
       options = { :start => paginate[:per_page] * (paginate[:page] - 1), :len => paginate[:per_page] }.merge(options) if paginate
       results = index.search(query, options)
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -21,6 +21,9 @@ ActiveRecord::Schema.define do
     t.string :tags
     t.text :description
   end
+  create_table :companies do |t|
+    t.string :name
+  end
 end
 
 class Product < ActiveRecord::Base
@@ -33,6 +36,15 @@ class Product < ActiveRecord::Base
     indexes :description
   end
 end
+
+class Company < ActiveRecord::Base
+  include Tanker
+
+  tankit 'tanker_integration_tests' do
+    indexes :name
+  end
+end
+
 
 describe 'An imaginary store' do
 
@@ -67,6 +79,9 @@ describe 'An imaginary store' do
     @products_in_database = Product.all
 
     Product.tanker_reindex
+
+    @apple = Company.create(:name => 'apple')
+    Company.tanker_reindex
   end
 
   describe 'basic searching' do
@@ -105,6 +120,11 @@ describe 'An imaginary store' do
       results = Product.search_tank('IPHONE')
       results.should include(@iphone)
       results.should have(1).product
+    end
+
+    it "should not find a Company when searching Product" do
+      results = Product.search_tank("apple")
+      results.should_not include(@apple)
     end
   end
 

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -271,7 +271,7 @@ describe Tanker do
 
     it 'should be able to use multi-value query phrases' do
       Person.tanker_index.should_receive(:search).with(
-        'name:(hey! location_id:(1) location_id:(2)) OR last_name:(hey! location_id:(1) location_id:(2)) OR __any:(hey! location_id:(1) location_id:(2)) __type:("Person")',
+        '(name:(hey! location_id:(1) location_id:(2)) OR last_name:(hey! location_id:(1) location_id:(2)) OR __any:(hey! location_id:(1) location_id:(2))) __type:("Person")',
         anything
       ).and_return({'results' => [], 'matches' => 0})
 


### PR DESCRIPTION
When searching a given model, it is possible for search to return instances of other models. Two conditions conspire to make this possible:
1. the two models share common attribute names
2. the `__type` part of the query is not being respected

This request adds one test, which calls `Product.search_tank("apple")`. I added a new model called Company and one new company called "apple".

When that search is run, this query is generated: `name:(apple) OR href:(apple) OR tags:(apple) OR description:(apple) OR __any:(apple) __type:(\"Product\")`

The search_tank results should include only Products, but they also include the new Company.

The addition of the new Company causes three existing specs to fail since their results now include the new Company (even though they only searched Product).

This request only includes the new test. I'm new to IndexTank and Tanker, and query code looks a little delicate for my novice hands.

I'd also like to offer my sincere thanks to the friendly folks on #indextank for helping me diagnose this problem.
