### PR TITLE
quick fix: conditional indexing now removes stales from index too

### DIFF
--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -392,10 +392,15 @@ module Tanker
     end
 
     # update a create instance from index tank
+    # or remove it if not indexable anymore
     def update_tank_indexes
-      tanker_config.index.add_document(
-        it_doc_id, tanker_index_data, tanker_index_options
-      ) if tanker_indexable?
+      if tanker_indexable?
+        tanker_config.index.add_document(
+          it_doc_id, tanker_index_data, tanker_index_options
+        )
+      else
+        delete_tank_indexes
+      end
     end
 
     # delete instance from index tank

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -216,6 +216,17 @@ describe Tanker do
         end
       end
 
+      it "should remove object from index if conditions are not met" do
+        @dummy_class.send(:tankit, 'dummy index') do
+          indexes :something
+          conditions { false }
+        end
+        dummy_instance = @dummy_class.new
+        dummy_instance.should_receive(:delete_tank_indexes).once
+
+        dummy_instance.update_tank_indexes
+      end
+
       it 'should be indexable when no conditions are given' do
         @dummy_class.send(:tankit, 'dummy index') do
           indexes :something


### PR DESCRIPTION
previous to this, if you had an instance that passed conditional indexing and then for some reason stops being indexable (say, it goes from 'active' to 'deleted'), the act of saving the instance would do no good.

now, the instance is automatically removed from the index in these cases.
