### PR TITLE
Resolves issue with missing categories and functions - issue #62

### DIFF
--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -269,6 +269,12 @@ module Tanker
           self.tanker_config.indexes << [key, value]
         end
 
+        config.categories.each do |key, value|
+          self.tanker_config.categories << [key, value]
+        end
+
+        self.tanker_config.functions.merge!(config.functions)
+
         unless config.variables.empty?
           self.tanker_config.variables do
             instance_exec &config.variables.first

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'tanker'
 require 'rspec'
 
-Rspec.configure do |c|
+RSpec.configure do |c|
   c.mock_with :rspec
 end
 

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -193,7 +193,13 @@ describe Tanker do
         include dummy_module
 
         tankit 'another index' do
-          indexes :email
+          indexes :email, :category => true
+
+          functions do
+            {
+                0 => '-age'
+            }
+          end
         end
       end
 
@@ -201,6 +207,8 @@ describe Tanker do
       dummy_instance.tanker_config.index_name.should == 'another index'
       Hash[*dummy_instance.tanker_config.indexes.flatten].keys.include?(:name).should == true
       Hash[*dummy_instance.tanker_config.indexes.flatten].keys.include?(:email).should == true
+      Hash[*dummy_instance.tanker_config.categories.flatten].keys.include?(:email).should == true
+      Hash[*dummy_instance.tanker_config.functions.flatten].keys.include?(0).should == true
 
       Tanker.instance_variable_set(:@included_in, Tanker.included_in - [dummy_class])
     end


### PR DESCRIPTION
- This is happens when extending your index definition with default configs: https://github.com/kidpollo/tanker#extend-your-index-definitions

Also fixed a few other failing specs, removed a duplicate spec, and fixed a deprecation warning.
