### PR TITLE
Fix test suite

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,11 @@ RSpec::Core::RakeTask.new(:integration) do |t|
   t.rcov_opts = ['--exclude', 'spec']
 end
 
-require 'rake/rdoctask'
+begin
+  require 'rake/rdoctask'
+rescue
+  require 'rdoc/task'
+end
 Rake::RDocTask.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
 

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -144,7 +144,7 @@ describe Tanker do
       end
 
       dummy_instance = @dummy_class.new
-      dummy_instance.stub!(:id => 1)
+      dummy_instance.stub(:id => 1)
       dummy_instance.tanker_index_data[:something].should == "second"
     end
 
@@ -174,7 +174,7 @@ describe Tanker do
       end
 
       dummy_instance = @dummy_class.new
-      dummy_instance.stub!(:id => 1)
+      dummy_instance.stub(:id => 1)
       dummy_instance.tanker_index_data[:__type].should == 'MySpecialModel'
     end
 
@@ -433,7 +433,7 @@ describe Tanker do
           }]
         })
 
-      Foo::Bar.should_receive(:find_all_by_id).and_return([stub(:id => 42)])
+      Foo::Bar.should_receive(:find_all_by_id).and_return([double(:id => 42)])
 
       Foo::Bar.search_tank('bar')
     end


### PR DESCRIPTION
Fixes

``` shell
rake aborted!
ERROR: 'rake/rdoctask' is obsolete and no longer supported. Use 'rdoc/task' (available in RDoc 2.4.2+) instead.
/.../tanker/Rakefile:44:in `<top (required)>'
(See full trace by running task with --trace)
```

which will also fix Travis build. 

In addition also fixes a couple deprecation warning coming from RSpec.
