### PR TITLE
use where method when find_all_by_id is not available

### DIFF
--- a/lib/tanker.rb
+++ b/lib/tanker.rb
@@ -165,6 +165,8 @@ module Tanker
           klass_const = constantize(klass)
           if klass_const.respond_to?('find_all_by_id')
             id_map[klass] = klass_const.find_all_by_id(ids)
+          elsif klass_const.respond_to?('where')
+            id_map[klass] = klass_const.where(id: ids)
           else
             id_map[klass] = klass_const.find(ids)
           end

--- a/spec/tanker_spec.rb
+++ b/spec/tanker_spec.rb
@@ -324,6 +324,48 @@ describe Tanker do
       collection.current_page.should == 1
     end
 
+    it 'should use the rails4 find_by finder method if available on model class' do
+      Person.tanker_index.should_receive(:search).and_return(
+        {
+          "matches" => 1,
+          "results" => [{
+                          "docid"  => Person.new.it_doc_id,
+                          "name"   => 'pedro',
+                          "__type" => 'Person',
+                          "__id"   => '1'
+                        }],
+          "search_time" => 1
+        }
+      )
+
+      Person.should_receive(:where).and_return(
+        [Person.new]
+      )
+
+      Person.search_tank('hey!')
+    end
+
+    it 'should use find if neither where nor find_all_by_id are available on the model class' do
+      Person.tanker_index.should_receive(:search).and_return(
+        {
+          "matches" => 1,
+          "results" => [{
+                          "docid"  => Person.new.it_doc_id,
+                          "name"   => 'pedro',
+                          "__type" => 'Person',
+                          "__id"   => '1'
+                        }],
+          "search_time" => 1
+        }
+      )
+
+      Person.should_receive(:find).and_return(
+        [Person.new]
+      )
+
+      Person.search_tank('hey!')
+    end
+
     it 'should handle string and integer ids in search results' do
       Person.tanker_index.should_receive(:search).and_return(
         {


### PR DESCRIPTION
In rails4, it looks like tanker will use `find_all_by_id` if `activerecord-deprecated_finders`is in your Gemfile but otherwise it will fall back to `find`.  `find` behaves differently than `find_all_by_id` because it will raise an exception unless all models are present.  To allow the current behavior to continue in a rails4, without requiring `activerecord-deprecated_finders` as a dependency, we can use the `where` method if it is available. I'm not actually sure why we wouldn't use `where` all the time.  The use of a dynamic finder was added with commit 02b623a2 and I couldn't tell from the commit message why this was done (maybe it was just done so it could be stubbed for testing).  I would argue that falling back to `find` prior to rails3 (or for some other ORM) isn't the right behavior either, but I'll leave that for others to deal with.  I have added a test that describes the behavior when none of the dynamic finder methods are available.

Thanks for your consideration,

Andrew
